### PR TITLE
Validate for all extracted slots

### DIFF
--- a/rasa_core_sdk/forms.py
+++ b/rasa_core_sdk/forms.py
@@ -251,9 +251,10 @@ class FormAction(Action):
         # extract requested slot
         slot_to_fill = tracker.get_slot(REQUESTED_SLOT)
         if slot_to_fill:
-            for slot, value in self.extract_requested_slot(dispatcher,
+            slot_values.update(self.extract_requested_slot(dispatcher,
                                                            tracker,
-                                                           domain).items():
+                                                           domain))
+            for slot, value in slot_values.items():
                 validate_func = getattr(self, "validate_{}".format(slot),
                                         lambda *x: value)
                 slot_values[slot] = validate_func(value, dispatcher, tracker,


### PR DESCRIPTION
**Proposed changes**:
- Modified `validate` function to validate all extracted slots. Previously it validates only requested slot but not extracted other slots.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog